### PR TITLE
fix-async-api-app-multiple-products

### DIFF
--- a/api-implementation/server/api/services/asyncapi/asyncapigenerator.ts
+++ b/api-implementation/server/api/services/asyncapi/asyncapigenerator.ts
@@ -95,9 +95,9 @@ class AsyncApiGenerator {
     let apiProducts: APIProduct[] = [];
     for (const productName of app.apiProducts) {
       const results = await ApiProductsService.all({ name: productName, apis: [apiName] });
-      if (results.length != 1) {
+      if (results.length > 1) {
         throw new ErrorResponseInternal(500, 'Find multiple matching documents for API Product Name');
-      } else {
+      } else if (results.length==1){
         apiProducts = apiProducts.concat(results);
       }
     }


### PR DESCRIPTION
fixed an issue where retrieving an Async API spec for an App results in an error if the app is associated with multiple API Products