### PR TITLE
refacto-openapi-pattern-length

### DIFF
--- a/api-implementation/server/common/api.yml
+++ b/api-implementation/server/common/api.yml
@@ -235,7 +235,7 @@ components:
        example: "123e4567-e89b-12d3-a456-426655440000"
        minLength: 0
        maxLength: 64
-       pattern: "[a-zA-Z0-9_-]{0,64}"
+       pattern: "[a-zA-Z0-9_-]*"
       meta:
        type: object
        additionalProperties: true
@@ -281,7 +281,7 @@ components:
           example: mqtt
           minLength: 2
           maxLength: 256
-          pattern: "[a-zA-z0-9\\-\\.]{0,256}"
+          pattern: "[a-zA-z0-9\\-\\.]*"
         summary:
           $ref: "#/components/schemas/CommonDescription"
         unpublishedTime:
@@ -304,7 +304,7 @@ components:
           type: string
           minLength: 0
           maxLength: 1024
-          pattern: "[\\s\\S]{0,1024}"
+          pattern: "[\\s\\S]*"
           default: apiProduct
       required:
       - id
@@ -323,7 +323,7 @@ components:
           example: model
           minLength: 0
           maxLength: 512
-          pattern: ".{0,512}"
+          pattern: ".*"
         type:
           type: string
           description: type of the parameter
@@ -341,7 +341,7 @@ components:
             type: string
             minLength: 1
             maxLength: 512
-            pattern: ".{0,512}"
+            pattern: ".*"
           example:
           - A
           - T
@@ -371,7 +371,7 @@ components:
           example: 7avdj5n26cq
           minLength: 0
           maxLength: 64
-          pattern: "[a-zA-Z0-9_-]{0,64}"
+          pattern: "[a-zA-Z0-9_-]*"
         createdTime:
           $ref: '#/components/schemas/CommonTimestampInteger'
         updatedTime:
@@ -412,7 +412,7 @@ components:
           example: 7avdj5n26cq
           minLength: 1
           maxLength: 128
-          pattern: "[a-zA-Z0-9_-]{0,64}"
+          pattern: "[a-zA-Z0-9_-]*"
         overwrite:
           description: indicates if an existing API entity shall be replaced
           type: boolean
@@ -1418,7 +1418,7 @@ components:
       properties:
         baseUrl:
           type: string
-          pattern: "https?:\\/\\/[A-Za-z\\.:0-9\\-]*.{0,200}$"
+          pattern: "https?:\\/\\/[A-Za-z\\.:0-9\\-]*.*$"
           example: https://solace.cloud/v1
           minLength: 0
           maxLength: 200
@@ -1551,7 +1551,7 @@ components:
       properties:
         uri:
           type: string
-          pattern: "https?:\\/\\/[A-Za-z\\.:0-9\\-]*.{0,200}$"
+          pattern: "https?:\\/\\/[A-Za-z\\.:0-9\\-]*.*$"
           minLength: 0
           maxLength: 200
         environments:
@@ -1606,7 +1606,7 @@ components:
           type: string
           minLength: 5
           maxLength: 2083
-          pattern: "[a-zA-Z0-9\\.\\-+]{2,64}:\\/\\/[A-Za-z\\.:0-9\\-]*.{0,2083}$"
+          pattern: "[a-zA-Z0-9\\.\\-+]{2,64}:\\/\\/[A-Za-z\\.:0-9\\-]*.*$"
           example: "amqp://mr1i5g7tif6z9h.messaging.solace.cloud:5672"
     About:
       type: object
@@ -1707,7 +1707,7 @@ components:
       type: string
       minLength: 0
       maxLength: 4096
-      pattern: "^[\\s\\S]{0,4096}$"
+      pattern: "^[\\s\\S]*$"
     CommonSolaceCloudObjectId:
       type: string
       description: id as used/issued by the back end apis, alphanumeric characters only
@@ -1726,7 +1726,7 @@ components:
       minLength: 8
       maxLength: 2083
       example: "https://solace.cloud/api/v0/eventPortal/apiProducts/abc123/asyncApi.json"
-      pattern: "https?:\\/\\/[A-Za-z\\.:0-9\\-]*.{0,2083}$"
+      pattern: "https?:\\/\\/[A-Za-z\\.:0-9\\-]*.*$"
     CommonTopic:
       type: string
       minLength: 2
@@ -1737,14 +1737,14 @@ components:
       type: string
       minLength: 1
       maxLength: 32
-      pattern: "[_\\-\\S\\.]{0,100}"
+      pattern: "[_\\-\\S\\.]*"
       example: "3.1.1-alpha"
     MsgVpnName:
       type: string
       minLength: 1
       maxLength: 32
       example: "API-GW-EU:AWS:1"
-      pattern: "^[^*^?]{0,256}$"
+      pattern: "^[^*^?]*$"
 security:
   - OpenId: []
   - BasicAuth: []
@@ -2003,7 +2003,7 @@ paths:
                           minLength: 0
                           maxLength: 1024
                           example: NO_DB_CONNECTION
-                          pattern: "[\\S\\s]{0,1024}"
+                          pattern: "[\\S\\s]*"
                   details:
                     type: array
                     minItems: 0
@@ -2017,7 +2017,7 @@ paths:
                           example: NO_DB_CONNECTION
                           minLength: 0
                           maxLength: 1024
-                          pattern: "[\\S\\s]{0,1024}"
+                          pattern: "[\\S\\s]*"
         '400':
            $ref: '#/components/responses/BadRequest'
         '401':


### PR DESCRIPTION
removed all length restrictions in reg-epressions, as minLength and maxLenght are also already set