### PR TITLE
fix-reverse-app-permissions

### DIFF
--- a/api-implementation/server/api/services/broker/aclmanager.ts
+++ b/api-implementation/server/api/services/broker/aclmanager.ts
@@ -490,9 +490,10 @@ class ACLManager {
         });
         channel[Object.keys(channel)[0]].permissions = Array.from(new Set(subscribePermissions));
       });
+      // revert the permissions to match the Async API.
       var permissions: Permissions = {
-        publish: subscribeExceptions,
-        subscribe: publishExceptions
+        publish: publishExceptions,
+        subscribe: subscribeExceptions
       }
       return permissions;
     } catch (err) {


### PR DESCRIPTION
Swapped the permission operations sub/pub) to match Async API instead of broker ACL