### PR TITLE
Feat optional event portal access

### DIFF
--- a/api-implementation/server/api/services/apis.service.ts
+++ b/api-implementation/server/api/services/apis.service.ts
@@ -16,6 +16,7 @@ import APIParameter = Components.Schemas.APIParameter;
 import CommonEntityNameList = Components.Schemas.CommonEntityNameList;
 import CommonEntityNames = Components.Schemas.CommonEntityNames;
 import APIProduct = Components.Schemas.APIProduct;
+import EventAPIProduct = Components.Schemas.EventAPIProduct;
 export interface APISpecification {
   name: string;
   specification: string;
@@ -97,8 +98,14 @@ export class ApisService {
 
   async import(body: Components.Schemas.APIImport): Promise<string> {
 
-    const apiSpec = await EventPortalFacade.getEventApiProductAsyncApi(body.id);
-    const api = await EventPortalFacade.getEventApiProduct(body.id);
+    let apiSpec;
+    let api: EventAPIProduct;
+    try {
+      apiSpec = await EventPortalFacade.getEventApiProductAsyncApi(body.id)
+      api = await EventPortalFacade.getEventApiProduct(body.id) ;
+    } catch (e){
+      throw new ErrorResponseInternal(500, `No Event POrtal Connectivity, Entity ${api.name} can not be imported`)
+    }
     const canImport = await this.readStrategy.canImport(api.name);
     if (!canImport) {
       throw new ErrorResponseInternal(422, `Entity ${api.name} can not be imported`)

--- a/api-implementation/server/api/services/apps.service.ts
+++ b/api-implementation/server/api/services/apps.service.ts
@@ -142,7 +142,7 @@ export class AppsService {
   }
 
   async create(name: string, newApp: App, ownerAttributes: Attributes): Promise<App> {
-    L.info(`App create request ${JSON.stringify(newApp)}`);
+    L.debug(`App create request ${JSON.stringify(newApp)}`);
     let appExists = null;
     try {
       appExists = await this.persistenceService.byName(name);

--- a/api-implementation/server/api/services/teams.service.ts
+++ b/api-implementation/server/api/services/teams.service.ts
@@ -121,12 +121,11 @@ export class TeamsService {
         name: team,
         displayName: team,
       };
+      L.info(`Auto creating team object ${team}`);
       this.create(teamObj);
     }
-    L.debug(teamObj);
     const app: TeamApp = AppFactory.createTeamApp(team, body);
 
-    L.debug(`App create request ${JSON.stringify(app)}`);
     try {
       const newApp: TeamApp = await AppsService.create(
         app.name,

--- a/api-implementation/server/common/api.yml
+++ b/api-implementation/server/common/api.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Solace API Management Connector
   description: 'Solace API Management Connector API. Note: basic authentication security mechanism is deprecated.'
-  version: 0.6.1
+  version: 0.6.2
 servers:
   - url: /v1
 
@@ -1513,6 +1513,26 @@ components:
             example: eyXhbGciOiJSUzI1NiIsImtpZCI6Im1hYXNfcHJvZF8yMDIwMDMyNiIsInR5cCI6IkpXVCJ9.eyJvcmcifiJzb2xhY2Vpb3R0ZWFtIiwib3JnVHlwZSI6IkVOVEVSUFJJU0UiLCJzdWIiOiIzZTJvY214MTA1IiwicGVybWlzc2lvbnMiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQXdBQU09IiwiYXBpVG9rZW5JZCI6Inlhb2wzc2ZveG03IiwiaXNzIjoiU29sYWNlIENvcnBvcmF0aW9uIiwiaWF0IjoxNjAzODA3NzQ1fQ.QIBpi5_U6b1DnAwbDbJiFIT0pomqa4AyOLtmSOEF6zhoxKMm4Y27WbILZnxnh_gpdX-tvt18Ycuck4xs3T5JjFfU3qrczRHSuj2vEdsCpDQWdyZTPV4NQ-zPxRvigTjaTlcdXin8XwMGh8nZdylgRMlRQjvotomnXQxgbUol0Kl1ziFFMybqeD10qCDsUW6Jv-PKibBN3cnCsWwPZX6d_XYUECs1AHjgs5pk-A8v3DHcnvbXiAP4XXrry6ztopAWKMc5rVFoB_WFY4yi0reuTYjn6Sf0g7vZxFifRZZHZmqZtNQUiX6S80eQG4kF3YDKlr5PfLDNp4iRfe0-3svIPw
           - "$ref": "#/components/schemas/CloudToken"
 
+    OrganizationResponse:
+      type: object
+      allOf: 
+        - $ref: "#/components/schemas/Organization"
+      required:
+      - name
+      additionalProperties: false
+      properties:
+        status: 
+          $ref: "#/components/schemas/OrganizationStatus"
+
+    OrganizationStatus:
+      type: object
+      additionalProperties: false
+      properties:
+        cloudConnectivity: 
+          type: boolean
+        eventPortalConnectivity: 
+          type: boolean
+      
     SempV2Authentication:
       description: Specifies how requests to the SEMPv2 Management API are authenticated, defaults to BasicAuth. If APIKey is specified the username returned in the Services/Environments response is used as API Key.
       type: object
@@ -2006,7 +2026,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: '#/components/schemas/OrganizationResponse'
         '400':
           description: "Bad request. Likely an invalid auth token provided."
           content:
@@ -2045,7 +2065,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Organization"
+                "$ref": "#/components/schemas/OrganizationResponse"
         '400':
            $ref: '#/components/responses/BadRequest'
         '401':
@@ -2080,7 +2100,7 @@ paths:
           content:
             "application/json":
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: '#/components/schemas/OrganizationResponse'
         '400':
           description: "Bad request. Likely an invalid auth token provided."
           content:

--- a/api-implementation/src/model/@types/api-model/index.d.ts
+++ b/api-implementation/src/model/@types/api-model/index.d.ts
@@ -730,6 +730,16 @@ declare namespace Components {
             sempV2Authentication?: SempV2Authentication;
             "cloud-token"?: string /* ^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$ */  | CloudToken;
         }
+        export interface OrganizationResponse {
+            status?: OrganizationStatus;
+            name: CommonName; // [a-zA-Z0-9_-]*
+            sempV2Authentication?: SempV2Authentication;
+            "cloud-token"?: string /* ^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$ */  | CloudToken;
+        }
+        export interface OrganizationStatus {
+            cloudConnectivity?: boolean;
+            eventPortalConnectivity?: boolean;
+        }
         /**
          * lists all the publish and subscribe topics an app has access to. Restrictions on   topic elements are taken into account.
          */
@@ -1494,7 +1504,7 @@ declare namespace Paths {
     }
     namespace GetOrganization {
         namespace Responses {
-            export type $200 = Components.Schemas.Organization;
+            export type $200 = Components.Schemas.OrganizationResponse;
             export type $400 = Components.Responses.BadRequest;
             export type $401 = Components.Responses.Unauthorized;
             export type $403 = Components.Responses.Forbidden;


### PR DESCRIPTION
Allow for cloud tokens that do not provide access to Event Portal in case it is not licensed. Behaviou is as follows - if a specific token for Event Portal is provided it MUST be valid. If a single token is provided it MUST be valid for Solace Cloud Service API but is NOT validated against Event Portal UNLESS the connector is running in Event Portal Proxy Mode.
POST, GET and PATCH of organizations resource return a status that indicates which APIs the token is valid for.