### PR TITLE
fix-apiproducts-asyncapi-missing-servers

### DIFF
--- a/api-implementation/server/api/services/broker.service.ts
+++ b/api-implementation/server/api/services/broker.service.ts
@@ -524,7 +524,7 @@ class BrokerService {
             .find((mp) => mp.endPoints.find((ep) => ep.transport == keys.protocol && ep.name == keys.name));
           const endpoint = tmp ? tmp.endPoints.find((ep) => ep.transport == keys.protocol) : null;
           let newEndpoint: Endpoint = endpoints.find(
-            (ep) => ep.uri == endpoint.uris[0]
+            (ep) => (ep.uri == endpoint.uris[0]  && ep.protocol.name == keys.name)
           );
           if (newEndpoint === undefined && endpoint) {
             newEndpoint = {


### PR DESCRIPTION
Servers were missing in the AsyncAPI if both secure-jms/smfs or jms/smf were activated in the product