### PR TITLE
add integration tests for the administration service

### DIFF
--- a/api-implementation/test/integ/administration/about.spec.ts
+++ b/api-implementation/test/integ/administration/about.spec.ts
@@ -1,0 +1,27 @@
+import 'mocha';
+import { expect } from 'chai';
+import path from 'path';
+import {
+  AdministrationService,
+  ApiError,
+} from '../../lib/generated/openapi';
+
+const scriptName: string = path.basename(__filename);
+
+describe(scriptName, function () {
+
+  it("should return 'about' information", async function () {
+
+    const response = await AdministrationService.about().catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to get about information; error="${reason.statusText}"`);
+    });
+
+    // Note: The about information is created when the server is build and currently
+    //       not available when running the integration tests.
+
+    expect(response, "proxy mode is incorrect").to.have.property("APIS_PROXY_MODE", false);
+    expect(response, "version is not set").to.have.property("version");
+  });
+
+});

--- a/api-implementation/test/integ/administration/common/test.setup.ts
+++ b/api-implementation/test/integ/administration/common/test.setup.ts
@@ -1,0 +1,56 @@
+import { Suite } from 'mocha';
+import path from 'path';
+import { PlatformAPIClient } from '../../../lib/api.helpers';
+import {
+  getMandatoryEnvVarValue,
+  TestContext,
+} from "../../../lib/test.helpers";
+
+const scriptName: string = path.basename(__filename);
+
+const env = {
+  solaceCloudBaseUrl: getMandatoryEnvVarValue(scriptName, 'PLATFORM_API_TEST_SOLACE_CLOUD_URL'),
+  solaceCloudToken: getMandatoryEnvVarValue(scriptName, 'PLATFORM_API_TEST_SOLACE_CLOUD_TOKEN'),
+  solaceEventPortalBaseUrl: getMandatoryEnvVarValue(scriptName, 'PLATFORM_API_TEST_SOLACE_EVENT_PORTAL_URL'),
+  solaceEventPortalToken: getMandatoryEnvVarValue(scriptName, 'PLATFORM_API_TEST_SOLACE_EVENT_PORTAL_TOKEN'),
+}
+
+/** The base URL for the Solace Cloud API. */
+export const solaceCloudBaseUrl: string = env.solaceCloudBaseUrl;
+
+/** The token for the Solace Cloud API. */
+export const solaceCloudToken: string = env.solaceCloudToken;
+
+/** The base URL for the Solace Cloud Event Portal API. */
+export const solaceEventPortalBaseUrl: string = env.solaceEventPortalBaseUrl;
+
+/** The token for the Solace Cloud Event Portal API. */
+export const solaceEventPortalToken: string = env.solaceEventPortalToken;
+
+/**
+ * Setup a test suite for administration service tests.
+ * 
+ * This method adds `beforeEach()` and `afterEach()` hooks.
+ * 
+ * The `beforeEach()` hook generates a new identifier for the {@link TestContext} and
+ * configures the {@link PlatformAPIClient} to use the management user.
+ * 
+ * The `afterEach()` hook configures the {@link PlatformAPIClient} to use the management user.
+ * 
+ * @param suite The test suite.
+ */
+ export function setupSuite(suite: Suite) {
+  suite.beforeEach(beforeEach);
+  suite.afterEach(afterEach);
+}
+
+/** beforeEach hook for a test suite */
+function beforeEach() {
+  TestContext.newItId();
+  PlatformAPIClient.setManagementUser();
+};
+
+/** afterEach hook for a test suite */
+function afterEach() {
+  PlatformAPIClient.setManagementUser();
+};

--- a/api-implementation/test/integ/administration/healthcheck.spec.ts
+++ b/api-implementation/test/integ/administration/healthcheck.spec.ts
@@ -1,0 +1,70 @@
+import 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import path from 'path';
+import * as fetch from 'fetch-with-proxy';
+import { databaseaccess } from '../../../src/databaseaccess';
+import {
+  AdministrationService,
+  ApiError,
+} from '../../lib/generated/openapi';
+
+const scriptName: string = path.basename(__filename);
+
+describe(scriptName, function () {
+
+  let databaseIsHealthyStub: sinon.SinonStub;
+  let fetchStub: sinon.SinonStub;
+
+  before(function () {
+    databaseIsHealthyStub = sinon.stub(databaseaccess, "isHealthy");
+    fetchStub = sinon.stub(fetch, "default");
+  });
+
+  beforeEach(function () {
+    databaseIsHealthyStub.reset();
+    databaseIsHealthyStub.resolves(true);
+    fetchStub.reset();
+    fetchStub.callThrough();
+  });
+
+  it("should return 'ok' if the server is healthy", async function () {
+
+    const response = await AdministrationService.healthcheck().catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`health check returned an unexpected error; error="${reason.statusText}"`);
+    });
+
+    expect(response, "status is incorrect").to.have.property("status", "ok");
+  });
+
+  it("should return 'failure' if the database is unhealthy", async function () {
+
+    databaseIsHealthyStub.resolves(false);
+
+    await AdministrationService.healthcheck().then(() => {
+      expect.fail("health check returned incorrect result");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([503]);
+    });
+  });
+
+  it("should return 'failure' if Solace PubSub+ Cloud cannot be accessed", async function () {
+
+    fetchStub.withArgs("https://api.solace.cloud/api/v0", sinon.match.any).resolves({ status: 404 });
+
+    await AdministrationService.healthcheck().then(() => {
+      expect.fail("health check returned incorrect result");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([503]);
+    });
+  });
+
+  after(function () {
+    databaseIsHealthyStub.restore();
+    fetchStub.restore();
+  });
+
+});

--- a/api-implementation/test/integ/administration/orgs.create.spec.ts
+++ b/api-implementation/test/integ/administration/orgs.create.spec.ts
@@ -1,0 +1,207 @@
+import 'mocha';
+import { expect } from 'chai';
+import path from 'path';
+import {
+  AdministrationService,
+  ApiError,
+  Organization,
+  OrganizationStatus,
+} from '../../lib/generated/openapi';
+
+import * as setup from './common/test.setup';
+import { PlatformAPIClient } from '../../lib/api.helpers';
+import { setPriority } from 'os';
+
+const scriptName: string = path.basename(__filename);
+
+describe(scriptName, function () {
+
+  setup.setupSuite(this);
+
+  const organizationName: string = "organization";
+
+  it("should create an organization", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': {
+        cloud: { baseUrl: setup.solaceCloudBaseUrl, token: setup.solaceCloudToken },
+        eventPortal: { baseUrl: setup.solaceEventPortalBaseUrl, token: setup.solaceEventPortalToken },
+      },
+    }
+
+    const response = await AdministrationService.createOrganization({ requestBody: organization }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to create organization; error="${reason.body.message}"`);
+    });
+
+    expect(response.name, "name is not correct").to.be.eql(organizationName);
+    expect(response['cloud-token'], "cloud-token is not set").to.be.not.empty;
+
+    const status: OrganizationStatus = {
+      cloudConnectivity: true,
+      eventPortalConnectivity: true,
+    }
+    expect(response.status, "status is not correct").to.deep.includes(status);
+  });
+
+  it("should create an organization with cloud token only", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': setup.solaceCloudToken,
+    }
+
+    const response = await AdministrationService.createOrganization({ requestBody: organization }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to create organization; error="${reason.body.message}"`);
+    });
+
+    expect(response.name, "name is not correct").to.be.eql(organizationName);
+    expect(response['cloud-token'], "cloud-token is not set").to.be.not.empty;
+
+    const status: OrganizationStatus = {
+      cloudConnectivity: true,
+      eventPortalConnectivity: true,
+    }
+    expect(response.status, "status is not correct").to.deep.includes(status);
+  });
+
+  it("should create an organization without a cloud token", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+    }
+
+    const response = await AdministrationService.createOrganization({ requestBody: organization }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to create organization; error="${reason.body.message}"`);
+    });
+
+    expect(response.name, "name is not correct").to.be.eql(organizationName);
+    expect(response.status, "status is not correct").to.be.empty;
+  });
+
+  it("should not create an organization if the user is not authorized", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+    }
+
+    PlatformAPIClient.setApiUser();
+
+    await AdministrationService.createOrganization({ requestBody: organization }).then(() => {
+      expect.fail("an unauthorized user created an organization");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([401]);
+    });
+  });
+
+  it("should not create an organization if the name is already used", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization });
+    await AdministrationService.createOrganization({ requestBody: organization }).then(() => {
+      expect.fail("an organization was created twice (duplicate)");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([422]);
+    });
+  });
+
+  it("should not create an organization with an invalid all-in-one token", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': "invalid",
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization }).then(() => {
+      expect.fail("an organization was created with an invalid all-in-one token");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([400]);
+    });
+  });
+
+  it("should not create an organization with an invalid cloud endpoint", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': {
+        cloud: { baseUrl: "https://invalid.me", token: setup.solaceCloudToken },
+        eventPortal: { baseUrl: setup.solaceEventPortalBaseUrl, token: setup.solaceEventPortalToken },
+      },
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization }).then(() => {
+      expect.fail("an organization was created with an invalid cloud endpoint");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([400]);
+    });
+  });
+
+  it("should not create an organization with an invalid cloud token", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': {
+        cloud: { baseUrl: setup.solaceCloudBaseUrl, token: "invalid" },
+        eventPortal: { baseUrl: setup.solaceEventPortalBaseUrl, token: setup.solaceEventPortalToken },
+      },
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization }).then(() => {
+      expect.fail("an organization was created with an invalid cloud endpoint");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([400]);
+    });
+  });
+
+  it("should not create an organization with an invalid event portal endpoint", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': {
+        cloud: { baseUrl: setup.solaceCloudBaseUrl, token: setup.solaceCloudToken },
+        eventPortal: { baseUrl: "https://invalid.me", token: setup.solaceEventPortalToken },
+      },
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization }).then(() => {
+      expect.fail("an organization was created with an invalid event portal endpoint");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([400]);
+    });
+  });
+
+  it("should not create an organization with an invalid event portal token", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': {
+        cloud: { baseUrl: setup.solaceCloudBaseUrl, token: setup.solaceCloudToken },
+        eventPortal: { baseUrl: setup.solaceEventPortalBaseUrl, token: "invalid" },
+      },
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization }).then(() => {
+      expect.fail("an organization was created with an invalid event portal endpoint");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([400]);
+    });
+  });
+
+  afterEach(async function () {
+    await AdministrationService.deleteOrganization({ organizationName: organizationName }).catch(() => { });
+  });
+
+});

--- a/api-implementation/test/integ/administration/orgs.delete.spec.ts
+++ b/api-implementation/test/integ/administration/orgs.delete.spec.ts
@@ -1,0 +1,67 @@
+import 'mocha';
+import { expect } from 'chai';
+import path from 'path';
+import {
+  AdministrationService,
+  ApiError,
+  Organization,
+} from '../../lib/generated/openapi';
+
+import * as setup from './common/test.setup';
+import { PlatformAPIClient } from '../../lib/api.helpers';
+
+const scriptName: string = path.basename(__filename);
+
+describe(scriptName, function () {
+
+  setup.setupSuite(this);
+
+  const organizationName: string = "organization";
+
+  it("should delete an organization", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization });
+
+    await AdministrationService.deleteOrganization({ organizationName: organizationName }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to delete organization; error="${reason.body.message}"`);
+    });
+  });
+
+  it("should not create an organization if the user is not authorized", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization });
+
+    PlatformAPIClient.setApiUser();
+
+    await AdministrationService.deleteOrganization({ organizationName: organizationName }).then(() => {
+      expect.fail("an unauthorized user deleted an organization");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([401]);
+    });
+  });
+
+  it("should not delete an organization that does not exist", async function () {
+
+    await AdministrationService.deleteOrganization({ organizationName: "unknown" }).then(() => {
+      expect.fail("n unknown organization was deleted");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([404]);
+    });
+  });
+
+  afterEach(async function () {
+    await AdministrationService.deleteOrganization({ organizationName: organizationName }).catch(() => { });
+  });
+
+});

--- a/api-implementation/test/integ/administration/orgs.get.spec.ts
+++ b/api-implementation/test/integ/administration/orgs.get.spec.ts
@@ -1,0 +1,120 @@
+import 'mocha';
+import { expect } from 'chai';
+import path from 'path';
+import {
+  AdministrationService,
+  ApiError,
+  Organization,
+} from '../../lib/generated/openapi';
+
+import * as setup from './common/test.setup';
+import { PlatformAPIClient } from '../../lib/api.helpers';
+import { TestContext } from '../../lib/test.helpers';
+
+const scriptName: string = path.basename(__filename);
+
+describe(scriptName, function () {
+
+  setup.setupSuite(this);
+
+  const organization1: Organization = {
+    name: "organization1",
+  }
+
+  const organization2: Organization = {
+    name: "organization2",
+    'cloud-token': setup.solaceCloudToken,
+  }
+
+  const organization3: Organization = {
+    name: "organization3",
+    'cloud-token': {
+      cloud: { baseUrl: setup.solaceCloudBaseUrl, token: setup.solaceCloudToken },
+      eventPortal: { baseUrl: setup.solaceEventPortalBaseUrl, token: setup.solaceEventPortalToken },
+    },
+  }
+
+  before(async function () {
+    TestContext.newItId();
+    PlatformAPIClient.setManagementUser();
+    await Promise.all([
+      AdministrationService.createOrganization({ requestBody: organization1 }),
+      AdministrationService.createOrganization({ requestBody: organization2 }),
+      AdministrationService.createOrganization({ requestBody: organization3 }),
+    ]);
+  });
+
+  it("should return an organization with name only", async function () {
+
+    const response = await AdministrationService.getOrganization({ organizationName: organization1.name }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to get organization; error="${reason.body.message}"`);
+    });
+
+    expect(response, "organization name is incorrect").to.have.property("name", organization1.name);
+    expect(response, "cloud-token is unexpected").to.not.have.property("cloud-token");
+    expect(response, "status is incorrect").to.have.property("status").that.is.an("object").that.is.empty;
+  });
+
+  it("should return an organization with all-in-one token", async function () {
+
+    const response = await AdministrationService.getOrganization({ organizationName: organization2.name }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to get organization; error="${reason.body.message}"`);
+    });
+
+    expect(response, "organization name is incorrect").to.have.property("name", organization2.name);
+    expect(response, "cloud-token is unexpected").to.have.property("cloud-token").that.is.a("string");
+    expect(response, "status is incorrect").to.have.property("status").that.includes({
+      "cloudConnectivity": true,
+      "eventPortalConnectivity": true,
+    });
+  });
+
+  it("should return an organization with cloud and event portal tokens", async function () {
+
+    const response = await AdministrationService.getOrganization({ organizationName: organization3.name }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to get organization; error="${reason.body.message}"`);
+    });
+
+    expect(response, "organization name is incorrect").to.have.property("name", organization3.name);
+    expect(response, "cloud-token is unexpected").to.have.property("cloud-token").that.is.an("object");
+    expect(response, "status is incorrect").to.have.property("status").that.includes({
+      "cloudConnectivity": true,
+      "eventPortalConnectivity": true,
+    });
+  });
+
+  it("should not return an organization if the user is not authorized", async function () {
+
+    PlatformAPIClient.setApiUser();
+
+    await AdministrationService.getOrganization({ organizationName: organization1.name }).then(() => {
+      expect.fail("an unauthorized user retrieved an organization");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([401]);
+    });
+  });
+
+  it("should not return an organization if the organization is unknown", async function () {
+
+    await AdministrationService.getOrganization({ organizationName: "unknown" }).then(() => {
+      expect.fail("an unknown organization was returned");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([404]);
+    });
+  });
+
+  after(async function() {
+    TestContext.newItId();
+    await Promise.all([
+      AdministrationService.deleteOrganization({ organizationName: organization1.name }),
+      AdministrationService.deleteOrganization({ organizationName: organization2.name }),
+      AdministrationService.deleteOrganization({ organizationName: organization3.name }),
+    ]);
+  });
+
+});

--- a/api-implementation/test/integ/administration/orgs.list.spec.ts
+++ b/api-implementation/test/integ/administration/orgs.list.spec.ts
@@ -1,0 +1,150 @@
+import 'mocha';
+import { expect } from 'chai';
+import path from 'path';
+import {
+  AdministrationService,
+  ApiError,
+  Organization,
+} from '../../lib/generated/openapi';
+
+import * as setup from './common/test.setup';
+import { PlatformAPIClient } from '../../lib/api.helpers';
+import { TestContext } from '../../lib/test.helpers';
+
+const scriptName: string = path.basename(__filename);
+
+describe(scriptName, function () {
+
+  setup.setupSuite(this);
+
+  const organization1: Organization = {
+    name: "organization1",
+  }
+
+  const organization2: Organization = {
+    name: "organization2",
+    'cloud-token': setup.solaceCloudToken,
+  }
+
+  const organization3: Organization = {
+    name: "organization3",
+    'cloud-token': {
+      cloud: { baseUrl: setup.solaceCloudBaseUrl, token: setup.solaceCloudToken },
+      eventPortal: { baseUrl: setup.solaceEventPortalBaseUrl, token: setup.solaceEventPortalToken },
+    },
+  }
+
+  before(async function () {
+    TestContext.newItId();
+    PlatformAPIClient.setManagementUser();
+    await Promise.all([
+      AdministrationService.createOrganization({ requestBody: organization1 }),
+      AdministrationService.createOrganization({ requestBody: organization2 }),
+      AdministrationService.createOrganization({ requestBody: organization3 }),
+    ]);
+  });
+
+  it("should return organizations", async function () {
+
+    const response = await AdministrationService.listOrganizations({}).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to list organizations; error="${reason.body.message}"`);
+    });
+
+    expect(response.length, "number of returned organizations is incorrect").to.be.equals(3);
+
+    let orgNames: Array<string> = [];
+    response.forEach(org => orgNames.push(org.name));
+
+    expect(orgNames, "list of organization names is incorrect").to.have.members([
+      organization1.name,
+      organization2.name,
+      organization3.name,
+    ]);
+  
+    const org1 = response[orgNames.indexOf(organization1.name)];
+    expect(org1, "1st organization is incorrect").to.not.have.property('cloud-token');
+
+    const org2 = response[orgNames.indexOf(organization2.name)];
+    expect(org2, "2nd organization is incorrect").to.have.property('cloud-token').that.is.a('string');
+
+    const org3 = response[orgNames.indexOf(organization3.name)];
+    expect(org3, "2nd organization is incorrect").to.have.property('cloud-token').that.is.an('object');
+  });
+
+  it("should return organizations for page #1", async function () {
+
+    const response = await AdministrationService.listOrganizations({ pageSize: 2 , pageNumber: 1 }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to list organizations; error="${reason.body.message}"`);
+    });
+
+    expect(response.length, "number of returned organizations is incorrect").to.be.equals(2);
+  });
+
+  it("should return organizations for page #2", async function () {
+
+    const response = await AdministrationService.listOrganizations({ pageSize: 2 , pageNumber: 2 }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to list organizations; error="${reason.body.message}"`);
+    });
+
+    expect(response.length, "number of returned organizations is incorrect").to.be.equals(1);
+  });
+
+  it("should return organizations sorted in ascending order", async function () {
+
+    const response = await AdministrationService.listOrganizations({ sortFieldName: "name", sortDirection: "asc" }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to list organizations; error="${reason.body.message}"`);
+    });
+
+    expect(response.length, "number of returned organizations is incorrect").to.be.equals(3);
+
+    let orgNames: Array<string> = [];
+    response.forEach(org => orgNames.push(org.name));
+
+    expect(orgNames, "order of organizations is incorrect").to.have.ordered.members(
+      [organization1.name, organization2.name, organization3.name].sort((a, b) => (a > b ? 1 : -1))
+    );
+  });
+
+  it("should return organizations sorted in descending order", async function () {
+
+    const response = await AdministrationService.listOrganizations({ sortFieldName: "name", sortDirection: "desc" }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to list organizations; error="${reason.body.message}"`);
+    });
+
+    expect(response.length, "number of returned organizations is incorrect").to.be.equals(3);
+
+    let orgNames: Array<string> = [];
+    response.forEach(org => orgNames.push(org.name));
+
+    expect(orgNames, "order of organizations is incorrect").to.have.ordered.members(
+      [organization1.name, organization2.name, organization3.name].sort((a, b) => (a > b ? -1 : 1))
+    );
+  });
+
+  it("should not return organizations if the user is not authorized", async function () {
+
+    PlatformAPIClient.setApiUser();
+
+    await AdministrationService.listOrganizations({}).then(() => {
+      expect.fail("an unauthorized user retrieved organizations");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([401]);
+    });
+  });
+
+  after(async function() {
+    TestContext.newItId();
+    await Promise.all([
+      AdministrationService.deleteOrganization({ organizationName: organization1.name }),
+      AdministrationService.deleteOrganization({ organizationName: organization2.name }),
+      AdministrationService.deleteOrganization({ organizationName: organization3.name }),
+    ]);
+  });
+
+});

--- a/api-implementation/test/integ/administration/orgs.update.spec.ts
+++ b/api-implementation/test/integ/administration/orgs.update.spec.ts
@@ -1,0 +1,111 @@
+import 'mocha';
+import { expect } from 'chai';
+import path from 'path';
+import {
+  AdministrationService,
+  ApiError,
+  Organization,
+  OrganizationResponse,
+} from '../../lib/generated/openapi';
+
+import * as setup from './common/test.setup';
+import { PlatformAPIClient } from '../../lib/api.helpers';
+
+const scriptName: string = path.basename(__filename);
+
+describe(scriptName, function () {
+
+  setup.setupSuite(this);
+
+  const organizationName: string = "organization";
+
+  it("should update the cloud token for an organization", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': {
+        cloud: { baseUrl: setup.solaceCloudBaseUrl, token: setup.solaceCloudToken },
+        eventPortal: { baseUrl: setup.solaceEventPortalBaseUrl, token: setup.solaceEventPortalToken },
+      },
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization });
+
+    const organizationPatch: Organization = {
+      name: organizationName,
+      'cloud-token': setup.solaceCloudToken,
+    }
+
+    const response = await AdministrationService.updateOrganization({ organizationName: organizationName, requestBody: organizationPatch }).catch((reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect.fail(`failed to update organization; error="${reason.body.message}"`);
+    });
+  
+    expect(response, "cloud-token is not set").to.have.property("cloud-token").that.is.a("string").that.is.not.empty;
+  });
+
+  it("should not update an organization if the user is not authorized", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization });
+
+    const organizationPatch: Organization = {
+      name: organizationName,
+      'cloud-token': setup.solaceCloudToken,
+    }
+
+    PlatformAPIClient.setApiUser();
+
+    await AdministrationService.updateOrganization({ organizationName: organizationName, requestBody: organizationPatch }).then(() => {
+      expect.fail("an unauthorized user updated an organization");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([401]);
+    });
+  });
+
+  it("should not update an organization that does not exist", async function () {
+
+    const organizationPatch: Organization = {
+      name: "unknown",
+      'cloud-token': setup.solaceCloudToken,
+    }
+
+    await AdministrationService.updateOrganization({ organizationName: "unknown", requestBody: organizationPatch }).then(() => {
+      expect.fail("an unknown organization was updated");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([404]);
+    });
+  });
+
+  it("should not update an organization if the new cloud token is invalid", async function () {
+
+    const organization: Organization = {
+      name: organizationName,
+      'cloud-token': setup.solaceCloudToken,
+    }
+
+    await AdministrationService.createOrganization({ requestBody: organization });
+
+    const organizationPatch: Organization = {
+      name: organizationName,
+      'cloud-token': "invalid",
+    }
+
+    await AdministrationService.updateOrganization({ organizationName: organizationName, requestBody: organizationPatch }).then(() => {
+      expect.fail("an organization was updated with an invalid token");
+    }, (reason) => {
+      expect(reason, `error=${reason.message}`).is.instanceof(ApiError);
+      expect(reason.status, `status is not correct`).to.be.oneOf([400]);
+    });
+  });
+
+  afterEach(async function () {
+    await AdministrationService.deleteOrganization({ organizationName: organizationName }).catch(() => { });
+  });
+
+});

--- a/api-implementation/test/integ/integration.spec.ts
+++ b/api-implementation/test/integ/integration.spec.ts
@@ -1,8 +1,14 @@
 import 'mocha';
 
-// describe("orgs", function() {
-//   require('./orgs/orgs.create.spec.ts')
-// });
+describe("administration", function() {
+  require('./administration/orgs.create.spec.ts')
+  require('./administration/orgs.delete.spec.ts')
+  require('./administration/orgs.get.spec.ts')
+  require('./administration/orgs.list.spec.ts')
+  require('./administration/orgs.update.spec.ts')
+  require('./administration/healthcheck.spec.ts')
+  require('./administration/about.spec.ts')
+});
 
 describe("apps", function() {
   require('./apps/apps.developer.create.spec.ts')


### PR DESCRIPTION
This feature adds integration tests for the following operations:
- Create an organization
- Delete an organization
- Get an organization
- List organizations
- Update an organization
- Perform a health check
- Get the about information