### PR TITLE
fix-api-read-local-api-spec-loading

### DIFF
--- a/api-implementation/server/api/services/apis/read.local.strategy.ts
+++ b/api-implementation/server/api/services/apis/read.local.strategy.ts
@@ -44,7 +44,7 @@ class ApisReadLocalStrategy implements ApisReadStrategy {
             const apiInfos: APIInfo[] = await this.apiInfoPersistenceService.all();
             for (const info of apiInfos){
               if (!info.apiParameters){
-                const spec: string = (await this.apiInfoPersistenceService.byName(info.name));
+                const spec: string = (await this.persistenceService.byName(info.name)).specification;
                 info.apiParameters = await AsyncAPIHelper.getAsyncAPIParameters(spec);
               }
             }


### PR DESCRIPTION
accidentally tried to read the spec from apiInfo instead of apis collection