### PR TITLE
Fix app set credentials provisioning

### DIFF
--- a/api-implementation/server/api/services/apps.service.ts
+++ b/api-implementation/server/api/services/apps.service.ts
@@ -253,9 +253,11 @@ export class AppsService {
     );
 
     const validated = await this.validate(app, true, appNotModified as App);
-    if (app.credentials && app.credentials.secret && !app.credentials.secret.consumerSecret) {
+    if (app.credentials && app.credentials.secret) {
       // regenerate a consumerSecret if omitted / partial secret is sent
-      app.credentials.secret.consumerSecret = AppHelper.generateConsumerSecret();
+      if (!app.credentials.secret.consumerSecret){
+        app.credentials.secret.consumerSecret = AppHelper.generateConsumerSecret();
+      }
       // set the issuedAt and calculate expiresAt timestamp
       const now: number = Date.now();
       app.credentials.issuedAt = now;

--- a/api-implementation/server/api/services/broker.service.ts
+++ b/api-implementation/server/api/services/broker.service.ts
@@ -112,6 +112,8 @@ class BrokerService {
       return true;
     }
     catch (e) {
+      L.error(`Error reprovisioning app `, e);
+      L.error(e);
       const r = await this.provisionApp(appUnmodified as App, ownerAttributes, true);
       return false;
     }

--- a/api-implementation/server/api/services/broker/queuemanager.ts
+++ b/api-implementation/server/api/services/broker/queuemanager.ts
@@ -98,10 +98,18 @@ export class QueueManager {
       }
       try {
         const q = await apiClient.getMsgVpnQueue(service.msgVpnName, objectName);
+        L.trace(`queue exists ${objectName}`);
+        const disableQ: MsgVpnQueue = {
+          queueName: objectName,
+          msgVpnName: service.msgVpnName,
+          ingressEnabled: false,
+          egressEnabled: false
+        };
+        const disableQueueResponse = await apiClient.updateMsgVpnQueue(service.msgVpnName, objectName, disableQ);
         const updateResponseMsgVpnQueue = await apiClient.updateMsgVpnQueue(service.msgVpnName, objectName, newQ);
         L.debug(`createQueues updated ${app.internalName}`);
       } catch (e) {
-        L.debug(`createQueues lookup  failed ${JSON.stringify(e)}`);
+        L.warn(`createQueues lookup  failed ${JSON.stringify(e)}`);
         try {
           const q = await apiClient.createMsgVpnQueue(service.msgVpnName, newQ);
         } catch (e) {


### PR DESCRIPTION
Fixed issue that resulted in re-provisioning error if the app consumerKey was changed. (Root cause - attempt to update a queue with ingress/egress flows enabled)