### PR TITLE
fix-app-provisioning-limit-diff-attribute-size

### DIFF
--- a/api-implementation/server/api/services/solaceconfig.service.ts
+++ b/api-implementation/server/api/services/solaceconfig.service.ts
@@ -169,7 +169,7 @@ export class SolaceConfigService {
         }
         configSet.attributes.push({
             name: 'diff',
-            value: JSON.stringify(appDiff).substring(0, 1048576),
+            value: JSON.stringify(appDiff).substring(0, 30000),
         });
 
         // get everything that was replaced and figure out which of the replacements need an absent task for old object


### PR DESCRIPTION
Limiting the diff that is stored for each revision to 30K characters to align with the OpenAPI specification of the attributes schema