### PR TITLE
fix-ep-2.0-importer-create-valid-internal-names

### DIFF
--- a/api-implementation/server/api/services/importer/eventportalimportertaskimpl.ts
+++ b/api-implementation/server/api/services/importer/eventportalimportertaskimpl.ts
@@ -83,7 +83,7 @@ export default class EventPortalImporterTaskImpl {
         }
 
         for (const plan of prodVersion.version.plans) {
-          const apiProductId = `${prodVersion.version.eventApiProductId}-${plan.name}`;
+          const apiProductId = connectorFacade.createInternalName(`${prodVersion.version.eventApiProductId}-${plan.name}`);
           const policy = plan.policies[0] as SolacePolicy;
           const clientOptions: ClientOptions = {
             guaranteedMessagingEnabled: policy.guaranteedMessaging,
@@ -100,7 +100,7 @@ export default class EventPortalImporterTaskImpl {
             }
           }
 
-          const apiNames: string[] = apis.map(api => { return api.name });
+          const apiNames: string[] = apis.map(api => { return connectorFacade.createInternalName(api.name) });
           mappedAttributes.push({ name: EPSystemAttributes.EP_EAP_OBJECT, value: JSON.stringify(prodVersion) });
           const product: APIProduct = {
             apis: apiNames,


### PR DESCRIPTION
Whitespaces were not stripped from names and other elements in the data from EP 2.0 which resulted in invalid entity names in the connector (mostly names containing whitespaces). All non-allowed characters are now stripped from entity names used in the connector