### PR TITLE
fix-ep2-integration-base-url-resolution

### DIFF
--- a/api-implementation/src/cloudtokenhelper.ts
+++ b/api-implementation/src/cloudtokenhelper.ts
@@ -77,8 +77,13 @@ export async function getEventPortalBaseUrl(): Promise<string> {
   let token: any = null;
   token = ns.getStore().get(ContextConstants.CLOUD_TOKEN);
   if (token == null || isString(token)) {
+    const epVersion = process.env.EP_VERSION || '1';
     L.trace('using default event portal base url');
-    return 'https://api.solace.cloud/api/v0/eventPortal';
+    if (epVersion == '2') {
+      return 'https://api.solace.cloud';
+    } else {
+      return 'https://api.solace.cloud/api/v0/eventPortal';
+    }
   } else {
     return token.eventPortal.baseUrl;
   }


### PR DESCRIPTION
When a simple token (string) was used in the organisation the EP base URL did not resolve to EP 2.0 correctly