### PR TITLE
fix-sempv2-client-apikey-auth

### DIFF
--- a/api-implementation/server/api/services/broker/sempv2clientfactory.ts
+++ b/api-implementation/server/api/services/broker/sempv2clientfactory.ts
@@ -32,12 +32,16 @@ export class SempV2ClientFactory {
     ns.getStore().set(SEMPV2_BASE, sempProtocol.endPoints.find(j => j.name === "Secured SEMP Config").uris[0]);
     ns.getStore().set(SEMPV2_USER, sempProtocol.username);
     ns.getStore().set(SEMPV2_PASSWORD, sempProtocol.password);
-
+    const org: Organization = ns.getStore().get(ContextConstants.ORG_OBJECT);
+    const isAPIKeyAuth: boolean = (org.sempV2Authentication && org.sempV2Authentication.authType == 'APIKey')?true:false;
+    
     const options: ApiOptions = {
-      baseUrl: sempProtocol.endPoints.find(j => j.name === "Secured SEMP Config").uris[0],
-      username: sempProtocol.username,
-      password: sempProtocol.password,
+      baseUrl: sempProtocol.endPoints.find(j => j.name === "Secured SEMP Config").uris[0],      
       defaultHeaders: getHeaders
+    }
+    if (!isAPIKeyAuth){
+      options.username=sempProtocol.username;
+      options.password=sempProtocol.password;
     }
     return new AllServiceDefault(options);
   }

--- a/api-implementation/server/api/services/solace.config.tasks/solace.task.ts
+++ b/api-implementation/server/api/services/solace.config.tasks/solace.task.ts
@@ -17,7 +17,7 @@ export abstract class SEMPv2Task extends TaskTemplate {
     constructor(taskConfig: SEMPv2TaskConfig) {
         super(taskConfig);
         this.apiClient = SempV2ClientFactory.getSEMPv2Client(taskConfig.environment.service as Service);
-        SempV2ClientFactory.getSEMPv2ClientVersion(taskConfig.environment.service as Service).then(p=>{
+        SempV2ClientFactory.getSEMPv2ClientVersion(taskConfig.environment.service as Service).then(p => {
             this.apiVersion = p;
         });
     }
@@ -48,13 +48,18 @@ export abstract class SEMPv2Task extends TaskTemplate {
         let msg: string = `${name} failure: ${e.message}`;
         if (e['body']) {
             const err: SempMetaOnlyResponse = e['body'];
-            L.error(err.meta.error.status);
-            L.error(err.meta.error.description);
-            data = err.meta.error;
-            msg = `${name} failure: ${err.meta.error.status} ${err.meta.error.description}`;
+            if (err?.meta?.error) {
+                L.error(err.meta.error.status);
+                L.error(err.meta.error.description);
+                data = err.meta.error;
+                msg = `${name} failure: ${err.meta.error.status} ${err.meta.error.description}`;
+            } else {
+                L.error(e['body']);
+            }
         } else {
             L.error(e);
         }
+        L.error(msg);
         const result: TaskResult = {
             data: data,
             log: {


### PR DESCRIPTION
fixed issue which led to HTTP authorization header being sent in addition to an API key if the PASI key option for SMEPv2 authentication is actived